### PR TITLE
Add a News posts page and add to About menu

### DIFF
--- a/content/about/news/2025-12-08-service-start.md
+++ b/content/about/news/2025-12-08-service-start.md
@@ -1,21 +1,15 @@
 ---
-title: Cirrus EX4000 service start - charging enabled and updated login address
+layout: 'news'
+title: Cirrus EX4000 service start
 date: 2025-12-08T10:00:00
 ---
-Dear Cirrus EX4000 Users,
+
 
 We are pleased to announce that the new Cirrus EX4000 service has now started. Jobs finishing after 0800 GMT today (Mon 8 Dec 2025) will be charged against budgets.
 
 You should now use "login.cirrus.ac.uk" to access the system rather than "preview.cirrus.ac.uk". The preview address will be removed at some time in the future. If you previously had a entry in your "known_hosts" file for the old Cirrus login nodes, you may need to manualy remove this before you can login. An example of the error and how you can fix it are included at the bottom of this message.
 
 If you have any questions or run into issues with the new Cirrus EX4000 system, please contact the service desk: support@cirrus.ac.uk.
-
-Regards
-
-Andy Turner
-
-Cirrus Service Desk
-
 
 ---
 
@@ -41,9 +35,3 @@ When you try to login to the new service using "login.cirrus.ac.uk".
 
 To fix this, you should delete the offending line from the file. The error indicates the line to delete (in the example above, it is line number 2 in the file).
 
----
-
-This message was sent to the
-Cirrus [Major Announcements] list.
-
-Instructions on how to manage your mailing list subscriptions are at: https://epcced.github.io/safe-docs/safe-for-users/#user-mailing-options

--- a/content/about/news/2025-12-08-service-start.md
+++ b/content/about/news/2025-12-08-service-start.md
@@ -1,0 +1,49 @@
+---
+title: Cirrus EX4000 service start - charging enabled and updated login address
+date: 2025-12-08T10:00:00
+---
+Dear Cirrus EX4000 Users,
+
+We are pleased to announce that the new Cirrus EX4000 service has now started. Jobs finishing after 0800 GMT today (Mon 8 Dec 2025) will be charged against budgets.
+
+You should now use "login.cirrus.ac.uk" to access the system rather than "preview.cirrus.ac.uk". The preview address will be removed at some time in the future. If you previously had a entry in your "known_hosts" file for the old Cirrus login nodes, you may need to manualy remove this before you can login. An example of the error and how you can fix it are included at the bottom of this message.
+
+If you have any questions or run into issues with the new Cirrus EX4000 system, please contact the service desk: support@cirrus.ac.uk.
+
+Regards
+
+Andy Turner
+
+Cirrus Service Desk
+
+
+---
+
+If you have an entry in your known hosts file for old Cirrus login nodes you may see an error similar to:
+
+```
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+It is also possible that a host key has just been changed.
+The fingerprint for the ED25519 key sent by the remote host is
+SHA256:WX5NbmOOYZdcm0HN3KgSkkI67+cSudpll0E1R6n9nto.
+Please contact your system administrator.
+Add correct host key in /Users/auser/.ssh/known_hosts to get rid of this message.
+Offending ECDSA key in /Users/auser/.ssh/known_hosts:2
+Host key for login.cirrus.ac.uk has changed and you have requested strict checking.
+Host key verification failed.
+```
+
+When you try to login to the new service using "login.cirrus.ac.uk".
+
+To fix this, you should delete the offending line from the file. The error indicates the line to delete (in the example above, it is line number 2 in the file).
+
+---
+
+This message was sent to the
+Cirrus [Major Announcements] list.
+
+Instructions on how to manage your mailing list subscriptions are at: https://epcced.github.io/safe-docs/safe-for-users/#user-mailing-options

--- a/content/about/news/_index.md
+++ b/content/about/news/_index.md
@@ -1,0 +1,3 @@
+---
+title: Cirrus service news
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -25,6 +25,7 @@ pluralizelisttitles = false
     logo = "img/cirrus-small.png"
     logo_small = "img/cirrus-icon.png"
     style = "cirrus"
+    date_format = "02 Jan 2006"
 
     about_us = "<p>EPCC provides world-class supercomputing and data services and facilities for science and business.</p>"
     copyright = "Copyright (c) 2025, EPCC; all rights reserved."
@@ -64,6 +65,12 @@ pluralizelisttitles = false
     name       = "Service Policies"
     url        = "/about/policies/"
     weight     = 4
+    parent     = "menu.about"
+
+[[menu.main]]
+    name       = "Service News"
+    url        = "/about/news/"
+    weight     = 5
     parent     = "menu.about"
 
 # Support menu

--- a/layouts/about/news/list.html
+++ b/layouts/about/news/list.html
@@ -21,24 +21,14 @@
                 <div class="row">
                     <!-- *** LEFT COLUMN *** -->
 
-                    <div class="col-md-9" id="blog-listing-medium">
+                    <div class="col-md-12" id="blog-listing-medium">
 
                         {{ $paginator := .Paginate (where .Data.Pages "Type" "in" .Site.Params.mainSections) }}
                         {{ range $paginator.Pages }}
                         <section class="post">
                             <div class="row">
-                                <div class="col-md-4">
-                                  <div class="image">
-                                      <a href="{{ .Permalink }}">
-                                          {{ if .Params.banner }}
-                                          <img src="{{ .Params.banner | relURL }}" class="img-responsive" alt="" />
-                                          {{ else }}
-                                          <img src="{{ "img/placeholder.png" | relURL }}" class="img-responsive" alt="" />
-                                          {{ end }}
-                                      </a>
-                                  </div>
-                                </div>
-                                <div class="col-md-8">
+
+                                <div class="col-md-12">
                                     <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
                                     <div class="clearfix">
                                         <p class="author-category">

--- a/layouts/page/list.html
+++ b/layouts/page/list.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+
+  <head>
+    {{ partial "headers.html" . }}
+    {{ partial "custom_headers.html" . }}
+  </head>
+
+  <body>
+
+    <div id="all">
+
+        {{ partial "top.html" . }}
+
+        {{ partial "nav.html" . }}
+
+        {{ partial "breadcrumbs.html" . }}
+
+        <div id="content">
+            <div class="container">
+                <div class="row">
+                    <!-- *** LEFT COLUMN *** -->
+
+                    <div class="col-md-9" id="blog-listing-medium">
+
+                        {{ $paginator := .Paginate (where .Data.Pages "Type" "in" .Site.Params.mainSections) }}
+                        {{ range $paginator.Pages }}
+                        <section class="post">
+                            <div class="row">
+                                <div class="col-md-4">
+                                  <div class="image">
+                                      <a href="{{ .Permalink }}">
+                                          {{ if .Params.banner }}
+                                          <img src="{{ .Params.banner | relURL }}" class="img-responsive" alt="" />
+                                          {{ else }}
+                                          <img src="{{ "img/placeholder.png" | relURL }}" class="img-responsive" alt="" />
+                                          {{ end }}
+                                      </a>
+                                  </div>
+                                </div>
+                                <div class="col-md-8">
+                                    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                                    <div class="clearfix">
+                                        <p class="author-category">
+                                          {{ if isset .Params "authors" }}
+					  {{ i18n "authorBy" }} {{ range $index, $author := .Params.authors }}{{ if $index }}, {{ end }}<a href="{{ (printf "%s/%s" ("authors" | relLangURL) ($author | urlize)) }}">{{ $author }}</a>{{ end }}
+                                          {{ end }}
+                                          {{ if isset .Params "categories" }}
+                                          {{ if gt (len .Params.categories) 0 }}
+                                          in 
+                                          {{ range $index, $category := .Params.categories }}{{ if $index }}, {{ end }}
+                                              <a href="{{ "categories/" | relLangURL }}{{ . | urlize | lower }}">{{ $category }}</a>{{ end }}
+                                          {{ end }}
+                                          {{ end }}
+
+                                        </p>
+                                        {{ if isset .Params "date" }}
+
+                                        {{ $createdAt := .Date.Format .Site.Params.date_format }}
+                                        {{ range $index, $month := slice "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December" }}
+                                            {{ $createdAt = replace $createdAt $month (i18n $month) }}
+                                        {{ end }}
+
+                                        <p class="date-comments">
+                                            <a href="{{ .Permalink }}"><i class="far fa-calendar"></i> {{ $createdAt }}</a>
+                                        </p>
+                                        {{ end }}
+                                    </div>
+                                    {{ if not .Site.Params.recent_posts.hide_summary }}
+                                    <p class="intro">{{ .Summary }}</p>
+                                    <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
+                                    </p>
+                                    {{ end }}
+                                </div>
+                            </div>
+                        </section>
+                        {{ end }}
+
+                        <ul class="pager">
+                            {{ if .Paginator.HasPrev }}
+                            <li class="previous"><a href="{{ .Paginator.Prev.URL | relURL }}">&larr; {{ i18n "newer" }}</a></li>
+                            {{ else }}
+                            <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
+                            {{ end }}
+
+                            {{ if .Paginator.HasNext }}
+                            <li class="next"><a href="{{ .Paginator.Next.URL | relURL }}">{{ i18n "older" }} &rarr;</a></li>
+                            {{ else }}
+                            <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
+                            {{ end }}
+                        </ul>
+                    </div>
+                    <!-- /.col-md-9 -->
+
+                    <!-- *** LEFT COLUMN END *** -->
+
+                    <!-- *** RIGHT COLUMN ***
+       _________________________________________________________ -->
+
+                    <div class="col-md-3">
+
+                        <!-- *** MENUS AND WIDGETS *** -->
+
+                        {{ partial "sidebar.html" . }}
+
+                        <!-- *** MENUS AND FILTERS END *** -->
+
+                    </div>
+                    <!-- /.col-md-3 -->
+
+                    <!-- *** RIGHT COLUMN END *** -->
+
+                </div>
+                <!-- /.row -->
+            </div>
+            <!-- /.container -->
+        </div>
+        <!-- /#content -->
+
+        {{ partial "footer.html" . }}
+
+    </div>
+    <!-- /#all -->
+
+    {{ partial "scripts.html" . }}
+
+  </body>
+</html>


### PR DESCRIPTION
Jo requested that we add a News feature to the new Cirrus website. I have implemented this in Hugo with an index (list) page, with links to each post. It will benefit from some review of styling and adding of additional data such as Author, but I believe it is sufficient and functional for now